### PR TITLE
[Refractor] Deprecate isProfileCompleted, use getAccountDetails instead

### DIFF
--- a/src/main/java/com/thirdcc/webapp/service/dto/AccountDetailsDTO.java
+++ b/src/main/java/com/thirdcc/webapp/service/dto/AccountDetailsDTO.java
@@ -18,6 +18,8 @@ public class AccountDetailsDTO {
 
     private Set<String> authorities;
 
+    private Boolean isProfileCompleted;
+
     private Boolean isCurrentCCHead;
 
     private Boolean isCurrentAdministrator;
@@ -64,6 +66,15 @@ public class AccountDetailsDTO {
 
     public void setAuthorities(Set<String> authorities) {
         this.authorities = authorities;
+    }
+
+    @JsonProperty("isProfileCompleted")
+    public Boolean getProfileCompleted() {
+        return isProfileCompleted;
+    }
+
+    public void setProfileCompleted(Boolean isProfileCompleted) {
+        this.isProfileCompleted = isProfileCompleted;
     }
 
     @JsonProperty("isCurrentCCHead")

--- a/src/main/java/com/thirdcc/webapp/web/rest/AccountResource.java
+++ b/src/main/java/com/thirdcc/webapp/web/rest/AccountResource.java
@@ -129,6 +129,9 @@ public class AccountResource {
             .stream()
             .map(Authority::getName)
             .collect(Collectors.toSet());
+        boolean isBasicProfileCompleted = userService.isBasicProfileCompleted(user.getId());
+        boolean isUserUniInfoCompleted = userUniInfoService.isUserUniInfoCompleted(user.getId());
+        boolean isProfileCompleted = isBasicProfileCompleted && isUserUniInfoCompleted;
         boolean isCurrentCCHead = managementTeamSecurityExpression.isCurrentCCHead();
         boolean isCurrentAdministrator = managementTeamSecurityExpression.isCurrentAdministrator();
         Set<Long> eventHeadEventIds = eventCrewRepository
@@ -148,6 +151,7 @@ public class AccountResource {
         dto.setEmail(user.getEmail());
         dto.setImageUrl(user.getImageUrl());
         dto.setAuthorities(authorityNames);
+        dto.setProfileCompleted(isProfileCompleted);
         dto.setCurrentCCHead(isCurrentCCHead);
         dto.setCurrentAdministrator(isCurrentAdministrator);
         dto.setEventHeadEventIds(eventHeadEventIds);
@@ -225,6 +229,10 @@ public class AccountResource {
         }
     }
 
+    /**
+     * Use the {@link #getAccountDetails()} endpoint instead.
+     */
+    @Deprecated
     @GetMapping("/account/is-profile-completed")
     public ResponseEntity<Map<String, Boolean>> isProfileCompleted() {
         User currentUser = SecurityUtils


### PR DESCRIPTION
Related to f/e issue 
https://github.com/Five-Fishes/Club-Management-React-Client/issues/111

is using two endpoints, a bug will occur.